### PR TITLE
Deal with B = 0

### DIFF
--- a/ion_phys/common.py
+++ b/ion_phys/common.py
@@ -2,6 +2,7 @@ import numpy as np
 from collections import namedtuple
 import scipy.constants as consts
 from scipy.constants import hbar
+import warnings
 
 from . import operators
 from .utils import Lande_g
@@ -141,6 +142,10 @@ class Ion:
         self._sort_levels()  # arrange levels in energy order
 
         if B is not None:
+            if B == 0:
+                warnings.warn("B set to 1e-10 T to remove state degeneracies",
+                                stacklevel=3)
+                B = 1e-10
             self.setB(B)
 
     def slice(self, level):


### PR DESCRIPTION
When a user inputs B=0, the degenercay of the states causes the
calculation of eigenstates to crash. I have added a warning and
a specific case to change B = 0 to B = 1e-10 so that this doesn't
happen.