### PR TITLE
Removed transition_filter

### DIFF
--- a/ion_phys/common.py
+++ b/ion_phys/common.py
@@ -71,8 +71,7 @@ class LevelData:
 class Ion:
     """ Base class for storing atomic structure data. """
 
-    def __init__(self, B=None, *, I=0, levels={}, transitions={},
-                 level_filter=None):
+    def __init__(self, B=None, *, I=0, levels={}, transitions={}, level_filter=None):
         """
         :param B: Magnetic field (T). To change the B-field later, call
           :meth setB:
@@ -96,9 +95,7 @@ class Ion:
             levels = dict(filter(lambda lev: lev[0] in level_filter,
                                  levels.items()))
 
-        transition_filter = transitions.keys()
-
-        transition_filter = [trans for trans in transition_filter if
+        transition_filter = [trans for trans in transitions.keys() if
                              transitions[trans].lower in levels.keys()
                              and transitions[trans].upper in levels.keys()]
 

--- a/ion_phys/common.py
+++ b/ion_phys/common.py
@@ -72,7 +72,7 @@ class Ion:
     """ Base class for storing atomic structure data. """
 
     def __init__(self, B=None, *, I=0, levels={}, transitions={},
-                 level_filter=None, transition_filter=None):
+                 level_filter=None):
         """
         :param B: Magnetic field (T). To change the B-field later, call
           :meth setB:
@@ -82,8 +82,6 @@ class Ion:
           Transition objects.
         :param level_filter: list of Levels to include in the simulation, if
             None we include all levels.
-        :param transition_filter: list of Transitions to include in the
-          simulation, if None we include all relevant transitions.
 
         Internally, we store all information as vectors/matrices with states
         ordered in terms of increasing energies.
@@ -97,8 +95,8 @@ class Ion:
         if level_filter is not None:
             levels = dict(filter(lambda lev: lev[0] in level_filter,
                                  levels.items()))
-        if transition_filter is None:
-            transition_filter = transitions.keys()
+
+        transition_filter = transitions.keys()
 
         transition_filter = [trans for trans in transition_filter if
                              transitions[trans].lower in levels.keys()

--- a/ion_phys/ions/ca40.py
+++ b/ion_phys/ions/ca40.py
@@ -17,14 +17,12 @@ shelf = D52 = Level(n=4, S=1/2, L=2, J=5/2)
 
 
 class Ca40(Ion):
-    def __init__(self, B=None, *, level_filter=None, transition_filter=None):
+    def __init__(self, B=None, *, level_filter=None):
         """ 43Ca+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if
             None we include all levels.
-        :param transition_filter: list of Transitions to include in the
-          simulation, if None we include all relevant transitions.
         """
         levels = {
             ground_level: LevelData(g_J=2.00225664),
@@ -80,5 +78,4 @@ class Ca40(Ion):
         }
 
         super().__init__(B, I=0, levels=levels, transitions=transitions,
-                         level_filter=level_filter,
-                         transition_filter=transition_filter)
+                         level_filter=level_filter)

--- a/ion_phys/ions/ca40.py
+++ b/ion_phys/ions/ca40.py
@@ -17,8 +17,8 @@ shelf = D52 = Level(n=4, S=1/2, L=2, J=5/2)
 
 
 class Ca40(Ion):
-    def __init__(self, B=None, *, level_filter=None):
-        """ 43Ca+ atomic structure.
+    def __init__(self, *, B=None, level_filter=None):
+        """ 40Ca+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if

--- a/ion_phys/ions/ca43.py
+++ b/ion_phys/ions/ca43.py
@@ -25,14 +25,12 @@ shelf = D52 = Level(n=4, S=1/2, L=2, J=5/2)
 
 
 class Ca43(Ion):
-    def __init__(self, B=None, *, level_filter=None, transition_filter=None):
+    def __init__(self, B=None, *, level_filter=None):
         """ 43Ca+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)
         :param level_filter: list of Levels to include in the simulation, if
             None we include all levels.
-        :param transition_filter: list of Transitions to include in the
-          simulation, if None we include all relevant transitions.
         """
         levels = {
             ground_level: LevelData(
@@ -107,5 +105,4 @@ class Ca43(Ion):
         }
 
         super().__init__(B, I=7/2, levels=levels, transitions=transitions,
-                         level_filter=level_filter,
-                         transition_filter=transition_filter)
+                         level_filter=level_filter)

--- a/ion_phys/ions/ca43.py
+++ b/ion_phys/ions/ca43.py
@@ -25,7 +25,7 @@ shelf = D52 = Level(n=4, S=1/2, L=2, J=5/2)
 
 
 class Ca43(Ion):
-    def __init__(self, B=None, *, level_filter=None):
+    def __init__(self, *, B=None, level_filter=None):
         """ 43Ca+ atomic structure.
 
         :param B: B-field in Tesla (can be changed using :meth setB:)


### PR DESCRIPTION
Closes #7 

The kwarg transition_filter does not work properly. A fix is not easy
as the user may create conflicting filters using the level_filter.
Simplest solution is to remove transition_filter.