### PR TITLE
ion_phys/common.py: Fix calc_M1 function

### DIFF
--- a/ion_phys/common.py
+++ b/ion_phys/common.py
@@ -451,7 +451,7 @@ class Ion:
         eyeI = np.identity(I_dim)
 
         for level, data in self.levels.items():
-            lev = level.slice()
+            lev = data.slice()
             J_dim = np.rint(2.0*level.J+1).astype(int)
             dim = J_dim*I_dim
             eyeJ = np.identity(J_dim)
@@ -471,7 +471,7 @@ class Ion:
 
             u = [um, uz, up]
 
-            Mj = np.tile(data.M[lev], (dim, 1))
+            Mj = np.tile(self.M[lev], (dim, 1))
             Mi = Mj.T
             Q = (Mi - Mj)
 

--- a/ion_phys/examples/M1_transitions.py
+++ b/ion_phys/examples/M1_transitions.py
@@ -1,0 +1,22 @@
+from ion_phys.ions.ca43 import Ca43, ground_level
+import scipy.constants as sc
+
+uB = sc.physical_constants['Bohr magneton'][0]
+
+
+if __name__ == '__main__':
+    # all seems correct (e.g. agrees with TPH thesis table E.4)
+    ion = Ca43(level_filter=[ground_level])
+    ion.setB(146.0942e-4)   # magic field for 0->1 clock qubit
+    ion.calc_M1()
+
+    R = ion.M1/uB
+
+    for M3 in range(-3, +3 + 1):
+        for q in [-1, 0, 1]:
+            F4 = ion.index(ground_level, M3-q, F=4)
+            F3 = ion.index(ground_level, M3, F=3)
+            Rnm = R[ion.index(ground_level, M=M3, F=3),
+                    ion.index(ground_level, M=M3-q, F=4)]
+            print('Rnm for F=3, M={} -> F=4,'
+                  'M={}: {:.6f}'.format(M3, M3 - q, Rnm))


### PR DESCRIPTION
I have tried to extract the M1 matrix elements using the ```calc_M1() ``` function using the following MWE:
```python 
ion = Ca43()
ion.setB(11e-4)
ion.calc_M1()
```
However the function crashes (see below).

```python 
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-0703e4df7be4> in <module>
      2 ion = Ca43()
      3 ion.setB(11e-4)
----> 4 ion.calc_M1()

c:\ion_phys\ion_phys\common.py in calc_M1(self)
    452 
    453         for level, data in self.levels.items():
--> 454             lev = level.slice()
    455             J_dim = np.rint(2.0*level.J+1).astype(int)
    456             dim = J_dim*I_dim

AttributeError: 'Level' object has no attribute 'slice'
```
These bugs have been fixed. I have also added an example script to calculate the M1 matrix elements for all transitions which was used to check against TPH thesis Table E.4.